### PR TITLE
removing leftover enum value

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1996,9 +1996,6 @@ Enum(contract_inheritance) String(none) Value(0)
 EnumValue
 Enum(contract_inheritance) String(P2900R13) Value(1)
 
-EnumValue
-Enum(contract_inheritance) String(P3653) Value(2)
-
 fcontracts-on-virtual-functions=
 C++ Joined RejectNegative Enum(contract_inheritance) Var(flag_contracts_on_virtual_functions) Init(0)
 -fcontracts-on-virtual-functions=[none|P2900R13] Select how contracts are inherited for virtual functions


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
