### PR TITLE
removing left over warning flag

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1987,10 +1987,6 @@ fcontracts-nonattr-definition-check=
 C++ Joined RejectNegative Enum(on_off) Var(flag_contracts_nonattr_definition_check) Init(1)
 -fcontracts-nonattr-definition-check=[on|off]	Enable or disable contract checks on the definition side for all functions (default on).
 
-Wsuggest-explicit-contract
-C++ ObjC++ Var(suggest_explicit_contract) Warning
-Warn about functions with implicitly inherited contracts.
-
 fcoroutines
 C++ LTO Var(flag_coroutines)
 Enable C++ coroutines (experimental).


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
